### PR TITLE
Added ElevenLabs TTS for Group Announcements

### DIFF
--- a/Sonos.indigoPlugin/Contents/Server Plugin/Actions.xml
+++ b/Sonos.indigoPlugin/Contents/Server Plugin/Actions.xml
@@ -499,6 +499,7 @@
 				<List>
 					<Option value="FILE">File</Option>
 					<Option value="POLLY">Amazon Polly</Option>
+					<Option value="ELEVENLABS">ElevenLabs</Option>
 					<Option value="APPLE">Apple Speech</Option>					
 					<Option value="TTS">Google Text To Speech</Option>
 					<Option value="IVONA">IVONA Text To Speech</Option>
@@ -659,6 +660,20 @@
 			<Field id="POLLY_voice" type="menu" visibleBindingId="ttsORfile" visibleBindingValue="POLLY">
 				<Label>Voice:</Label>
 				<List class="self" method="getPollyVoices" dynamicReload="yes"/>
+			</Field>
+
+			<!-- ElevenLabs TTS message to read -->
+			<Field id="ELEVENLABS_setting" type="textfield" visibleBindingId="ttsORfile" visibleBindingValue="ELEVENLABS">
+				<Label>Message:</Label>
+			</Field>
+			<!-- Voice selection dropdown -->
+			<Field id="ELEVENLABS_voice" type="menu" visibleBindingId="ttsORfile" visibleBindingValue="ELEVENLABS">
+				<Label>Voice:</Label>
+				<List class="self" method="getElevenLabsVoices" dynamicReload="yes"/>
+			</Field>
+			<!-- ElevenLabs language code input -->
+			<Field id="ELEVENLABS_language" type="textfield" visibleBindingId="ttsORfile" visibleBindingValue="ELEVENLABS">
+				<Label>Language code (e.g. "en"):</Label>
 			</Field>
 
 			<Field id="APPLE_setting" type="textfield" visibleBindingId="ttsORfile" visibleBindingValue="APPLE">

--- a/Sonos.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/Sonos.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -147,6 +147,17 @@
 	</Field>
 	<Field id="simpleSeparator7" type="separator"/>
 
+	<Field id="ElevenLabsNote" type="label" fontColor="darkgray" fontSize="small" alignWithControl="false">
+		<Label>Check this box if you have an account with ElevenLabs and wish to use it for group announcements. [https://elevenlabs.io]</Label>
+	</Field>
+	<Field type="checkbox" id="ElevenLabs" tooltip="ElevenLabs account?">
+		<Label>ElevenLabs:</Label>
+	</Field>
+	<Field type="textfield" id="ElevenLabsAPIKey" tooltip="ElevenLabs API key" visibleBindingId="ElevenLabs" visibleBindingValue="true">
+		<Label>API key:</Label>
+	</Field>
+	<Field id="simpleSeparator8" type="separator"/>
+
 	<Field id="MSTranslateNote" type="label" fontColor="darkgray" fontSize="small" alignWithControl="false">
 		<Label>Check this box if you have registered a user account with Microsoft Translate and wish to use it for group announcements. [https://www.microsoft.com/en-us/translator/getstarted.aspx]</Label>
 	</Field>
@@ -159,7 +170,7 @@
 	<Field type="textfield" id="MSTranslateClientSecret" tooltip="MS Translate Client Secret" visibleBindingId="MSTranslate" visibleBindingValue="true">
         	<Label>Client Secret:</Label>
 	</Field>
-	<Field id="simpleSeparator8" type="separator"/>
+	<Field id="simpleSeparator9" type="separator"/>
 
 	<Field id="UpdaterEmailsEnabledNote" type="label" fontColor="darkgray" fontSize="small" alignWithControl="false">
 		<Label>Check this box if you want to enable version update notifications. Email sending must also be configured in Indigo's preferences.</Label>
@@ -173,7 +184,7 @@
 	<Field id="updaterEmail" type="textfield" visibleBindingId="updaterEmailsEnabled" visibleBindingValue="true">
 		<Label>Email:</Label>
 	</Field>
-	<Field id="simpleSeparator9" type="separator"/>
+	<Field id="simpleSeparator10" type="separator"/>
 
 	<Field id="showDebugInLogNote" type="label" fontColor="darkgray" fontSize="small" alignWithControl="false">
 		<Label>Check the boxes below for additional information to log to the Indigo Event Log.  Basic Debugging must be checked for any other deubgging to function.</Label>

--- a/Sonos.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/Sonos.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -147,12 +147,14 @@
 	</Field>
 	<Field id="simpleSeparator7" type="separator"/>
 
+	<!-- ElevenLabs TTS options -->
 	<Field id="ElevenLabsNote" type="label" fontColor="darkgray" fontSize="small" alignWithControl="false">
 		<Label>Check this box if you have an account with ElevenLabs and wish to use it for group announcements. [https://elevenlabs.io]</Label>
 	</Field>
 	<Field type="checkbox" id="ElevenLabs" tooltip="ElevenLabs account?">
 		<Label>ElevenLabs:</Label>
 	</Field>
+	<!-- ElevenLabs API key - visible only if main option checked -->
 	<Field type="textfield" id="ElevenLabsAPIKey" tooltip="ElevenLabs API key" visibleBindingId="ElevenLabs" visibleBindingValue="true">
 		<Label>API key:</Label>
 	</Field>

--- a/Sonos.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Sonos.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -450,6 +450,9 @@ class Plugin(indigo.PluginBase):
     def getPollyVoices(self, filter="", valuesDict=None, typeId="", targetId=0):
         return self.Sonos.getPollyVoices()
 
+    def getElevenLabsVoices(self, filter="", valuesDict=None, typeId="", targetId=0):
+        return self.Sonos.getElevenLabsVoices()
+
     def getAppleVoices(self, filter="", valuesDict=None, typeId="", targetId=0):
         return self.Sonos.getAppleVoices()
 


### PR DESCRIPTION
The [ElevenLabs](https://elevenlabs.io) TTS voices offer inflected, accurate voices in multiple languages; and this pull request adds the ability to use these voices for Group Announcements in the plugin.

Use of this feature requires an account with ElevenLabs, an [API key](https://elevenlabs.io/api), and voices in the user's voice library.

## Plugin configuration UI:

<img width="478" alt="sonos_ui_config" src="https://github.com/user-attachments/assets/2ea05c9d-4a9c-4882-b043-f639e282bfd7" />

## Action configuration UI:

<img width="607" alt="Screenshot 2024-12-20 at 3 40 30 AM" src="https://github.com/user-attachments/assets/bb84576e-0a51-4fb7-a9d7-2f84166ed4c2" />

