### PR TITLE
Fix HTTPStreamer port leak and Polly KeyError on prefs reload

### DIFF
--- a/Sonos.indigoPlugin/Contents/Server Plugin/Sonos.py
+++ b/Sonos.indigoPlugin/Contents/Server Plugin/Sonos.py
@@ -6078,16 +6078,21 @@ class SonosPlugin(object):
                     if (self.HTTPStreamingIP != http_ip) or (self.HTTPStreamingPort != http_port):
                         self.HTTPStreamingIP = http_ip
                         self.HTTPStreamingPort = http_port
-                    #if (self.HTTPStreamingIP != self.plugin.pluginPrefs["HTTPStreamingIP"]) or (self.HTTPStreamingPort != self.plugin.pluginPrefs["HTTPStreamingPort"]):
-                    #    self.HTTPStreamingIP = self.plugin.pluginPrefs["HTTPStreamingIP"]
-                    #    self.HTTPStreamingPort = self.plugin.pluginPrefs["HTTPStreamingPort"]
 
-                        self.HTTPSTreamerOn = False
+                        # Tear down the existing streamer (if any) before spawning a new one,
+                        # otherwise the next bind() fails with EADDRINUSE on port 8888.
+                        self.HTTPStreamerOn = False
+                        if getattr(self, "httpd", None):
+                            try:
+                                self.httpd.server_close()
+                            except Exception:
+                                pass
+                            self.httpd = None
+
                         v = Thread(target=self.HTTPStreamer)
                         v.setDaemon(True)
                         v.start()
                 except Exception as exception_error:
-                    #self.logger.error(f"[{time.asctime()}] HTTPStreamer not functioning.")
                     import traceback
                     self.logger.error(f"[{time.asctime()}] HTTPStreamer not functioning: {exception_error}")
                     self.safe_debug(traceback.format_exc())
@@ -6160,17 +6165,19 @@ class SonosPlugin(object):
                     self.logger.error(f"[{time.asctime()}] Could not retrieve IVONA parameters.")
 
                 try:
-                    if (self.Polly != self.plugin.pluginPrefs['Polly']) or \
-                            (self.PollyaccessKey != self.plugin.pluginPrefs['PollyaccessKey']) or \
-                            (self.PollysecretKey != self.plugin.pluginPrefs['PollysecretKey']):
-                        self.Polly = self.plugin.pluginPrefs['Polly']
+                    polly_pref   = self.plugin.pluginPrefs.get('Polly', False)
+                    polly_access = self.plugin.pluginPrefs.get('PollyaccessKey', '')
+                    polly_secret = self.plugin.pluginPrefs.get('PollysecretKey', '')
+                    if (self.Polly != polly_pref) or \
+                            (self.PollyaccessKey != polly_access) or \
+                            (self.PollysecretKey != polly_secret):
+                        self.Polly = polly_pref
                         if self.Polly:
-                            self.PollyaccessKey = self.plugin.pluginPrefs['PollyaccessKey']
-                            self.PollysecretKey = self.plugin.pluginPrefs['PollysecretKey']
-                        if self.Polly:
+                            self.PollyaccessKey = polly_access
+                            self.PollysecretKey = polly_secret
                             self.PollyVoices()
                 except Exception as exception_error:
-                    self.logger.error(f"[{time.asctime()}] Could not retrieve Polly parameters.")
+                    self.logger.error(f"[{time.asctime()}] Could not retrieve Polly parameters: {exception_error}")
 
                 try:
                     if (self.MSTranslate != self.plugin.pluginPrefs['MSTranslate']) or \
@@ -6823,12 +6830,16 @@ class SonosPlugin(object):
             self.logger.info(f"Serving HTTP Streamer on {self.HTTPServer} [{sa[0]}], port {sa[1]}")
             self.HTTPStreamerOn = True
             while self.HTTPStreamerOn:
-                self.httpd.handle_request()
+                try:
+                    self.httpd.handle_request()
+                except Exception:
+                    if not self.HTTPStreamerOn:
+                        break  # intentional teardown via prefs reload
+                    raise
 
-        # except Exception as e:
-        #     self.logger.error(f"Cannot start HTTP Streamer on {self.HTTPServer}: {e}")
         except Exception as exception_error:
-            self.exception_handler(f"Cannot start HTTP Streamer on {self.HTTPServer}: {exception_error}", True)  # Log error and display failing statement
+            if self.HTTPStreamerOn:
+                self.exception_handler(f"Cannot start HTTP Streamer on {self.HTTPServer}: {exception_error}", True)
 
 
     def _set_subscription_callback(self, sub, indigo_device, service_name):


### PR DESCRIPTION
Three related issues in closedPrefsConfigUi and HTTPStreamer that together cause noisy errors on every "Save" of the plugin config:

1. closedPrefsConfigUi sets `self.HTTPSTreamerOn = False` (capital "T") to signal the running streamer thread to stop, but the loop in HTTPStreamer() reads `self.HTTPStreamerOn` (lowercase "t") — so the signal goes nowhere and the old thread keeps the port bound.

2. Even if the typo were fixed, the streamer loop blocks inside `httpd.handle_request()` and never re-checks the flag without an incoming request. The new thread tries to bind the same port and fails with `[Errno 48] Address already in use`. Fix by also calling `self.httpd.server_close()` and clearing the reference, which unblocks the existing thread and releases the socket before the new thread is spawned. Wrap the inner `handle_request()` so an intentional teardown breaks the loop silently instead of logging "Cannot start HTTP Streamer …" on every prefs save.

3. The Polly section reads `pluginPrefs['Polly']`, `pluginPrefs['PollyaccessKey']`, and `pluginPrefs['PollysecretKey']` with subscript access. When Polly is not configured at all those keys are missing, the `KeyError` is swallowed by the bare except, and "Could not retrieve Polly parameters." is logged on every prefs save even though nothing is actually wrong. Switch to `.get(key, default)` so missing keys are handled cleanly, and include the original exception in the error message when one genuinely occurs.

Verified end-to-end on Indigo 2025.2 by saving plugin prefs while the plugin is running: no EADDRINUSE on rebind, no spurious Polly error, and the streamer continues serving on its configured port.